### PR TITLE
Document how to incorporate the original url path and method

### DIFF
--- a/compare_http.sh
+++ b/compare_http.sh
@@ -34,7 +34,6 @@ while read line; do
   "1")
     # log "Request type: Request"
     # Save the url path
-    # TODO strip GET params
     line1=$(echo -e "$payload" | head -n +1)
     echo "$line1" > $TMP_DIR/$request_id.line1
     ;;
@@ -46,6 +45,7 @@ while read line; do
     # log "Request type: Replayed Response"
     if [ -f "$TMP_DIR/$request_id" ]; then
       line1_bits=( $(cat "$TMP_DIR/$request_id.line1") )
+      # TODO strip GET params
       log "${line1_bits[0]} ${line1_bits[1]}"
       echo "$compare" | >&2 diff --suppress-common-lines --ignore-case --ignore-all-space $TMP_DIR/$request_id -
       rm "$TMP_DIR/$request_id"

--- a/compare_http.sh
+++ b/compare_http.sh
@@ -36,8 +36,7 @@ while read line; do
     # Save the url path
     # TODO strip GET params
     line1=$(echo -e "$payload" | head -n +1)
-    line1_bits=( $line1 )
-    echo "${line1_bits[1]}" > $TMP_DIR/$request_id.url_path
+    echo "$line1" > $TMP_DIR/$request_id.line1
     ;;
   "2")
     # log "Request type: Original Response"
@@ -46,10 +45,11 @@ while read line; do
   "3")
     # log "Request type: Replayed Response"
     if [ -f "$TMP_DIR/$request_id" ]; then
-      log $(cat "$TMP_DIR/$request_id.url_path")
+      line1_bits=( $(cat "$TMP_DIR/$request_id.line1") )
+      log "${line1_bits[0]} ${line1_bits[1]}"
       echo "$compare" | >&2 diff --suppress-common-lines --ignore-case --ignore-all-space $TMP_DIR/$request_id -
       rm "$TMP_DIR/$request_id"
-      rm "$TMP_DIR/$request_id.url_path"
+      rm "$TMP_DIR/$request_id.line1"
     else
       log "$request_id : Replayed response arrived before original response"
     fi

--- a/compare_http.sh
+++ b/compare_http.sh
@@ -33,6 +33,11 @@ while read line; do
   case ${header_bits[0]} in
   "1")
     # log "Request type: Request"
+    # Save the url path
+    # TODO strip GET params
+    line1=$(echo -e "$payload" | head -n +1)
+    line1_bits=( $line1 )
+    echo "${line1_bits[1]}" > $TMP_DIR/$request_id.url_path
     ;;
   "2")
     # log "Request type: Original Response"
@@ -41,8 +46,10 @@ while read line; do
   "3")
     # log "Request type: Replayed Response"
     if [ -f "$TMP_DIR/$request_id" ]; then
+      log $(cat "$TMP_DIR/$request_id.url_path")
       echo "$compare" | >&2 diff --suppress-common-lines --ignore-case --ignore-all-space $TMP_DIR/$request_id -
       rm "$TMP_DIR/$request_id"
+      rm "$TMP_DIR/$request_id.url_path"
     else
       log "$request_id : Replayed response arrived before original response"
     fi


### PR DESCRIPTION
This isn't intended to work that great, but to be a jumping off point to better functionality in the future.

the `rm` isn't guarded on purpose; `set -e` isn't set anyways.